### PR TITLE
Change arguments dict to accept them from current_app.url_map.iter_rules() directly

### DIFF
--- a/flask_autodoc/autodoc.py
+++ b/flask_autodoc/autodoc.py
@@ -89,6 +89,7 @@ class Autodoc(object):
                 continue
 
             func = current_app.view_functions[rule.endpoint]
+            arguments = rule.arguments if rule.arguments else ['None']
 
             if (groups and [True for g in groups if func in self.groups[g]]) or \
                     (not groups and func in self.groups[group]):
@@ -98,7 +99,7 @@ class Autodoc(object):
                         rule = "%s" % rule,
                         endpoint = rule.endpoint,
                         docstring = func.__doc__,
-                        args = list(func.func_code.co_varnames),
+                        args = arguments,
                         defaults = rule.defaults
                     )
                 )


### PR DESCRIPTION
The current method of using `func.func_code.co_varnames` to get the list of arguments bring back a list that has more names than the functions have arguments (listed in this issue: https://github.com/acoomans/flask-autodoc/issues/5).

This change will use the `arguments` property for a rule if one exists.
