### PR TITLE
Python 3 support and a more interactive doc page

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,18 @@ _title_ and _author_ will be available in the template:
 		{{title}}
 	{% endif %}
 	...
+### Interactive documentation
+
+Interactive documentation (allowing a user to preview REST calls on the documentation page) is available in a separate template included with flask-autodoc.
+To use this, call _html_ with the name of the interactive documentation template.
+        
+        auto.html(
+		
+		template='autodoc_interactive.html'
+		
+		title='Interactive Docs',
+		author='John Doe',
+	)
 
 ## Documentation sets
 

--- a/README.md
+++ b/README.md
@@ -93,9 +93,7 @@ Interactive documentation (allowing a user to preview REST calls on the document
 To use this, call _html_ with the name of the interactive documentation template.
 
 	auto.html(
-		
-		template='autodoc_interactive.html'
-		
+		template='autodoc_interactive.html',
 		title='Interactive Documentation',
 		author='John Doe',
 	)

--- a/README.md
+++ b/README.md
@@ -94,9 +94,9 @@ To use this, call _html_ with the name of the interactive documentation template
 
 	auto.html(
 		
-		template='custom_documentation.html'
+		template='autodoc_interactive.html'
 		
-		title='My Documentation',
+		title='Interactive Documentation',
 		author='John Doe',
 	)
 	

--- a/README.md
+++ b/README.md
@@ -12,7 +12,11 @@ Flask-Autodoc is a Flask extension that automatically creates documentation for 
 
 ## Requirements
 
-Flask-Autodoc is compatible with Python versions 2 and 3; and it depends only on Flask.
+Flask-Autodoc is compatible with Python versions 2 and 3
+
+It depends only on Flask.
+
+Optionally, if _docutils_ are installed, Flask-Autodoc will attempt to render docstrings as reStructuredText (and fall back to rendering them as plain text if that fails).
 
 ## Install
 
@@ -98,6 +102,18 @@ To use this, call _html_ with the name of the interactive documentation template
 		author='John Doe',
 	)
 	
+
+## Docstrings
+
+Docstrings are displayed under the endpoint path and parameters.
+
+In a custom template, it is recommended to use filters for rendering URLs and EOL:
+
+	{{doc.docstring | urlize | nl2br}}
+	
+If _docutils_ is installed (not required but recommended), reStructuredText docstrings can be rendered with the _docstring_ filter (safe disables jinja autoescaping):
+
+	{{doc.docstring | docstring | safe}}
 
 ## Documentation sets
 

--- a/README.md
+++ b/README.md
@@ -91,14 +91,15 @@ _title_ and _author_ will be available in the template:
 
 Interactive documentation (allowing a user to preview REST calls on the documentation page) is available in a separate template included with flask-autodoc.
 To use this, call _html_ with the name of the interactive documentation template.
-        
-        auto.html(
+
+	auto.html(
 		
-		template='autodoc_interactive.html'
+		template='custom_documentation.html'
 		
-		title='Interactive Docs',
+		title='My Documentation',
 		author='John Doe',
 	)
+	
 
 ## Documentation sets
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Apps in the _examples_ directory are an api for a blog:
 
 - _simple_ is a simple app
 - _factory_ uses blueprints
+- _custom_ uses a custom template
 
 Run with
 

--- a/examples/custom/blog.py
+++ b/examples/custom/blog.py
@@ -1,0 +1,122 @@
+from json import dumps
+
+from flask import Flask, redirect, request
+from flask.ext.autodoc import Autodoc
+
+
+app = Flask(__name__)
+app.debug = True
+auto = Autodoc(app)
+
+users = []
+posts = []
+
+
+class User(object):
+
+    def __init__(self, username):
+        self.username = username
+        users.append(self)
+        self.id = users.index(self)
+
+    def __repr__(self):
+        return dumps(self.__dict__)
+
+
+class Post(object):
+
+    def __init__(self, title, content, author):
+        self.title = title
+        self.content = content
+        posts.append(self)
+        self.id = posts.index(self)
+
+    def __repr__(self):
+        return dumps(self.__dict__)
+
+
+u = User('acoomans')
+Post('First post', 'This is the first awesome post', u)
+Post('Second post', 'This is another even more awesome post', u)
+
+
+@app.route('/')
+@app.route('/posts')
+@auto.doc(groups=['posts', 'public', 'private'])
+def get_posts():
+    """Return all posts."""
+    return '%s' % posts
+
+
+@app.route('/post/<int:id>')
+@auto.doc(groups=['posts', 'public', 'private'])
+def get_post(id):
+    """Return the post for the given id."""
+    return '%s' % posts[id]
+
+
+@app.route('/post', methods=["POST"])
+@auto.doc(groups=['posts', 'private'])
+def post_post():
+    """Create a new post.
+    Form Data: title, content, authorid.
+    """
+    authorid = request.form.get('authorid', None)
+    Post(request.form['title'],
+         request.form['content'],
+         users[authorid])
+    return redirect("/posts")
+
+
+@app.route('/users')
+@auto.doc(groups=['users', 'public', 'private'])
+def get_users():
+    """Return all users."""
+    return '%s' % users
+
+
+@app.route('/user/<int:id>')
+@auto.doc(groups=['users', 'public', 'private'])
+def get_user(id):
+    """Return the user for the given id."""
+    return '%s' % users[id]
+
+
+@app.route('/users', methods=['POST'])
+@auto.doc(groups=['users', 'private'])
+def post_user(id):
+    """Creates a new user.
+    Form Data: username.
+    """
+    User(request.form['username'])
+    redirect('/users')
+
+
+@app.route('/admin', methods=['GET'])
+@auto.doc(groups=['private'])
+def admin():
+    """Admin interface."""
+    return 'Admin interface'
+
+
+@app.route('/doc')
+@app.route('/doc/public')
+def public_doc():
+    return auto.html(
+        groups=['public'],
+        title='Blog Documentation',
+        template='custom_doc.html'
+    )
+
+
+@app.route('/doc/private')
+def private_doc():
+    return auto.html(
+        groups=['private'],
+        title='Private Documentation',
+        template='custom_doc.html'
+    )
+
+
+if __name__ == '__main__':
+    app.run()

--- a/examples/custom/templates/custom_doc.html
+++ b/examples/custom/templates/custom_doc.html
@@ -1,0 +1,261 @@
+<html>
+    <head>
+        <title>
+            {% if title is defined -%}
+                {{title}}
+            {% else -%}
+                Documentation
+            {% endif -%}
+        </title>
+        <style>
+            * {
+                margin: 0;
+                padding: 0;
+                font-family: Verdana, "Helvetica Neue", Arial, Helvetica, Geneva, sans-serif;
+            }
+
+            body {
+                margin: 10px;
+            }
+
+            div.mapping {
+                margin: 20px 20px;
+                padding: 20px 20px;
+                border: 1px solid #000;
+            }
+
+            ul.methods:before { font-weight: bold;content: "Methods: "; }
+            ul.methods li {
+                display: inline;
+                list-style: none;
+            }
+            ul.methods li:after { content: ","; }
+            ul.methods li:last-child:after { content: ""; }
+
+            ul.arguments:before { font-weight: bold;content: "Path Arguments: "; }
+            ul.arguments li {
+                display: inline;
+                list-style: none;
+            }
+            ul.arguments .argument { font-style:italic }
+            ul.arguments .default:not(:empty):before { content: "("; }
+            ul.arguments .default:not(:empty):after { content: ")"; }
+            ul.arguments li:after { content: ","; }
+            ul.arguments li:last-child:after { content: ""; }
+            
+            ul.queryparams:before {font-weight: bold; content: "Query String Arguments: "; }
+            ul.queryparams li {
+                display: inline;
+                list-style: none;
+            }
+            ul.queryparams .argument { font-style:italic }
+            ul.queryparams .default:not(:empty):before { content: "("; }
+            ul.queryparams .default:not(:empty):after { content: ")"; }
+            ul.queryparams li:after { content: ","; }
+            ul.queryparams li:last-child:after { content: ""; }
+
+            .docstring:before { font-weight: bold; content: "Description: "; }
+            
+            .url-input {
+                width: 100%;
+            }
+            
+            .call-output, .call-status-code {
+                border: 1px solid #00B4FF;
+                display: none;
+                width: 100%;
+            }
+            
+            .post-data {
+                width: 100%;
+            }
+            
+            .mapping-description {
+                display: none;
+            }
+            
+            .rule h2 {
+                background-color: #B8F7FF;
+                cursor: pointer; cursor: hand;
+            }
+        </style>
+        <style>
+            .jsonview {
+              font-family: monospace;
+              font-size: .8em;
+              white-space: pre-wrap; }
+            .jsonview .prop {
+              font-weight: bold; }
+            .jsonview .null {
+              color: red; }
+            .jsonview .bool {
+              color: blue; }
+            .jsonview .num {
+              color: blue; }
+            .jsonview .string {
+              color: green;
+              white-space: pre-wrap; }
+            .jsonview .string.multiline {
+              display: inline-block;
+              vertical-align: text-top; }
+            .jsonview .collapser {
+              position: absolute;
+              left: -1em;
+              cursor: pointer; }
+            .jsonview .collapsible {
+              transition: height 1.2s;
+              transition: width 1.2s; }
+            .jsonview .collapsible.collapsed {
+              height: .8em;
+              width: 1em;
+              display: inline-block;
+              overflow: hidden;
+              margin: 0; }
+            .jsonview .collapsible.collapsed:before {
+              content: "...";
+              width: 1em;
+              margin-left: .2em; }
+            .jsonview .collapser.collapsed {
+              transform: rotate(0deg); }
+            .jsonview .q {
+              display: inline-block;
+              width: 0px;
+              color: transparent; }
+            .jsonview li {
+              position: relative; }
+            .jsonview ul {
+              list-style: none;
+              margin: 0 0 0 2em;
+              padding: 0; }
+            .jsonview h1 {
+              font-size: 1.2em; }
+        </style>
+        <script src="//code.jquery.com/jquery-2.1.1.min.js"></script>
+        <script type="text/javascript" >
+            !function(e){var n,t,l,r;return l=function(){function e(e){null==e&&(e={}),this.options=e}return e.prototype.htmlEncode=function(e){return null!==e?e.toString().replace(/&/g,"&amp;").replace(/"/g,"&quot;").replace(/</g,"&lt;").replace(/>/g,"&gt;"):""},e.prototype.jsString=function(e){return e=JSON.stringify(e).slice(1,-1),this.htmlEncode(e)},e.prototype.decorateWithSpan=function(e,n){return'<span class="'+n+'">'+this.htmlEncode(e)+"</span>"},e.prototype.valueToHTML=function(e,n){var t;return null==n&&(n=0),t=Object.prototype.toString.call(e).match(/\s(.+)]/)[1].toLowerCase(),this[""+t+"ToHTML"].call(this,e,n)},e.prototype.nullToHTML=function(){return this.decorateWithSpan("null","null")},e.prototype.numberToHTML=function(e){return this.decorateWithSpan(e,"num")},e.prototype.stringToHTML=function(e){var n,t;return/^(http|https|file):\/\/[^\s]+$/i.test(e)?'<a href="'+this.htmlEncode(e)+'"><span class="q">"</span>'+this.jsString(e)+'<span class="q">"</span></a>':(n="",e=this.jsString(e),this.options.nl2br&&(t=/([^>\\r\\n]?)(\\r\\n|\\n\\r|\\r|\\n)/g,t.test(e)&&(n=" multiline",e=(e+"").replace(t,"$1<br />"))),'<span class="string'+n+'">"'+e+'"</span>')},e.prototype.booleanToHTML=function(e){return this.decorateWithSpan(e,"bool")},e.prototype.arrayToHTML=function(e,n){var t,l,r,o,s,i,a,p;for(null==n&&(n=0),l=!1,s="",o=e.length,r=a=0,p=e.length;p>a;r=++a)i=e[r],l=!0,s+="<li>"+this.valueToHTML(i,n+1),o>1&&(s+=","),s+="</li>",o--;return l?(t=0===n?"":" collapsible",'[<ul class="array level'+n+t+'">'+s+"</ul>]"):"[ ]"},e.prototype.objectToHTML=function(e,n){var t,l,r,o,s,i;null==n&&(n=0),l=!1,o="",r=0;for(s in e)r++;for(s in e)i=e[s],l=!0,o+='<li><span class="prop"><span class="q">"</span>'+this.jsString(s)+'<span class="q">"</span></span>: '+this.valueToHTML(i,n+1),r>1&&(o+=","),o+="</li>",r--;return l?(t=0===n?"":" collapsible",'{<ul class="obj level'+n+t+'">'+o+"</ul>}"):"{ }"},e.prototype.jsonToHTML=function(e){return'<div class="jsonview">'+this.valueToHTML(e)+"</div>"},e}(),"undefined"!=typeof module&&null!==module&&(module.exports=l),t={bindEvent:function(e,n){var t;return t=document.createElement("div"),t.className="collapser",t.innerHTML=n?"+":"-",t.addEventListener("click",function(e){return function(n){return e.toggle(n.target)}}(this)),e.insertBefore(t,e.firstChild),n?this.collapse(t):void 0},expand:function(e){var n,t;return t=this.collapseTarget(e),n=t.parentNode.getElementsByClassName("ellipsis")[0],t.parentNode.removeChild(n),t.style.display="",e.innerHTML="-"},collapse:function(e){var n,t;return t=this.collapseTarget(e),t.style.display="none",n=document.createElement("span"),n.className="ellipsis",n.innerHTML=" &hellip; ",t.parentNode.insertBefore(n,t),e.innerHTML="+"},toggle:function(e){var n;return n=this.collapseTarget(e),"none"===n.style.display?this.expand(e):this.collapse(e)},collapseTarget:function(e){var n,t;return t=e.parentNode.getElementsByClassName("collapsible"),t.length?n=t[0]:void 0}},n=e,r={collapse:function(e){return"-"===e.innerHTML?t.collapse(e):void 0},expand:function(e){return"+"===e.innerHTML?t.expand(e):void 0},toggle:function(e){return t.toggle(e)}},n.fn.JSONView=function(){var e,o,s,i,a,p,c;return e=arguments,null!=r[e[0]]?(a=e[0],this.each(function(){var t,l;return t=n(this),null!=e[1]?(l=e[1],t.find(".jsonview .collapsible.level"+l).siblings(".collapser").each(function(){return r[a](this)})):t.find(".jsonview > ul > li > .collapsible").siblings(".collapser").each(function(){return r[a](this)})})):(i=e[0],p=e[1]||{},o={collapsed:!1,nl2br:!1},p=n.extend(o,p),s=new l({nl2br:p.nl2br}),"[object String]"===Object.prototype.toString.call(i)&&(i=JSON.parse(i)),c=s.jsonToHTML(i),this.each(function(){var e,l,r,o,s,i;for(e=n(this),e.html(c),r=e[0].getElementsByClassName("collapsible"),i=[],o=0,s=r.length;s>o;o++)l=r[o],i.push("LI"===l.parentNode.nodeName?t.bindEvent(l.parentNode,p.collapsed):void 0);return i}))}}(jQuery);
+        </script>
+        <script type="text/javascript" >
+            $(document).ready(function(){
+                $(".rule h2").on("click", function(){
+                    $(this).parents(".mapping").find(".mapping-description").slideToggle();
+                });
+                
+                $(".url-input").each(function(){
+                    $(this).val(location.protocol+"//"+location.host+$(this).parents(".mapping").find("a.rule h2").text())
+                });
+                
+                $(".send-request").on("click", function(){
+                    var url = $(this).parents(".mapping").find(".url-input").val();
+                    var method = $(this).val();
+                    var outputLocation = $(this).parents(".mapping").find(".call-output");
+                    $(outputLocation).empty()
+                    var statusLocation = $(this).parents(".mapping").find(".call-status-code");
+                    $(statusLocation).empty()
+                    if (method == "POST" || method == "PUT"){
+                        $.ajax({
+                            contentType:"application/json; charset=UTF-8;",
+                            data:$(this).parents(".mapping").find(".post-data").val(),
+                            method:method,
+                            url:url,
+                            success:function(data, status, jqXHR){
+                                $(outputLocation).JSONView(data);
+                                $(outputLocation).show();
+                                $(statusLocation).text("Status: "+jqXHR.status);
+                                $(statusLocation).show();
+                            },
+                            error:function(jqXHR, status, reason){
+                                if(~jqXHR.getResponseHeader("Content-Type").indexOf("application/json")){
+                                    $(outputLocation).JSONView(jqXHR.responseText);
+                                } else {
+                                    $(outputLocation).text(jqXHR.responseText);
+                                }
+                                $(outputLocation).show();
+                                $(statusLocation).text("Status: "+jqXHR.status);
+                                $(statusLocation).show();
+                            }
+                        });
+                    } else {
+                        $.ajax({
+                            contentType:"application/json; charset=UTF-8;",
+                            method:method,
+                            url:url,
+                            success:function(data, status, jqXHR){
+                                $(outputLocation).JSONView(data);
+                                $(outputLocation).show();
+                                $(statusLocation).text("Status: "+jqXHR.status);
+                                $(statusLocation).show();
+                            },
+                            error:function(jqXHR, status, reason){
+                                if(~jqXHR.getResponseHeader("Content-Type").indexOf("application/json")){
+                                    $(outputLocation).JSONView(jqXHR.responseText);
+                                } else {
+                                    $(outputLocation).text(jqXHR.responseText);
+                                }
+                                $(outputLocation).show();
+                                $(statusLocation).text("Status: "+jqXHR.status);
+                                $(statusLocation).show();
+                            }
+                        });
+                    }
+                });
+            });
+        </script>
+    </head>
+    <body>
+        <h1>
+            {% if title is defined -%}
+                {{title}}
+            {% else -%}
+                Documentation
+            {% endif -%}
+        </h1>
+
+        {% for doc in autodoc %}
+        <div class="mapping">
+            <a id="rule-{{doc.rule|urlencode}}" class="rule"><h2>{{doc.rule|escape}}</h2></a>
+            <div class="mapping-description">
+                <ul class="methods">
+                        {% for method in doc.methods -%}
+                        <li class="method">{{method}}</li>
+                        {% endfor %}
+                </ul>
+                <ul class="arguments">
+                    {% for arg in doc.args %}
+                    <li>
+                        <span class="argument">{{arg}}</span>
+                        <span class="default">{{doc.defaults[arg]}}</span>
+                    </li>
+                    {% endfor %}
+                </ul>
+                <ul class="queryparams">
+                    {% for arg in doc.query_params %}
+                    <li>
+                        <span class="argument">{{arg}}</span>
+                    </li>
+                    {% endfor %}
+                </ul>
+                <p class="docstring">{{doc.docstring|urlize|nl2br}}</p>
+                <br/>
+                <p> <strong>URL:</strong> <input type="text" class="url-input"/></p>
+                <br/>
+                {% if "POST" in doc.methods or "PUT" in doc.methods %}
+                    <p><strong>Request Body:</strong> </p>
+                    <p><textarea class="post-data" rows=10 ></textarea></p>
+                    </br>
+                {% endif %}
+                <p>
+                {% for method in doc.methods %}
+                    {% if method != "OPTIONS" %}
+                        <input type="button" class="send-request" value="{{method}}"/>
+                    {% endif %}
+                {% endfor %}
+                </p><br/>
+                <p class="call-status-code"></p>
+                <p class="call-output"></p>
+            </div>
+        </div>
+    {% endfor %}
+    
+    
+    </body>
+</html>

--- a/flask_autodoc/autodoc.py
+++ b/flask_autodoc/autodoc.py
@@ -8,6 +8,8 @@ from flask import current_app, render_template, render_template_string
 from jinja2 import evalcontextfilter
 
 
+
+
 try:
     from flask import _app_ctx_stack as stack
 except ImportError:
@@ -54,6 +56,7 @@ class Autodoc(object):
             result = '\n\n'.join('%s' % p.replace('\n', '<br>\n')
                                  for p in _paragraph_re.split(value))
             return result
+        
 
     def doc(self, groups=None):
         """Add flask route to autodoc for automatic documentation
@@ -127,7 +130,7 @@ class Autodoc(object):
         else:
             return sorted(links, key=itemgetter('rule'))
 
-    def html(self, groups='all', template=None, **context):
+    def html(self, groups='all', template="autodoc_default.html", **context):
         """Return an html string of the routes specified by the doc() method
 
         A template can be specified. A list of routes is available under the
@@ -138,7 +141,7 @@ class Autodoc(object):
         By specifying the group or groups arguments, only routes belonging to
         those groups will be returned.
         """
-        if template:
+        if template and not os.path.exists(os.path.join(os.path.dirname(__file__), 'templates', str(template))):
             return render_template(template,
                                    autodoc=self.generate(groups=groups),
                                    **context)
@@ -146,7 +149,7 @@ class Autodoc(object):
             filename = os.path.join(
                 os.path.dirname(__file__),
                 'templates',
-                'autodoc_default.html'
+                template
             )
             with open(filename) as file:
                 content = file.read()

--- a/flask_autodoc/autodoc.py
+++ b/flask_autodoc/autodoc.py
@@ -7,7 +7,10 @@ import sys
 from flask import current_app, render_template, render_template_string
 from jinja2 import evalcontextfilter
 
-
+try:
+    from docutils.core import publish_parts
+except ImportError:
+    pass
 
 
 try:
@@ -57,6 +60,21 @@ class Autodoc(object):
                                  for p in _paragraph_re.split(value))
             return result
         
+        @app.template_filter()
+        @evalcontextfilter
+        def rst(eval_ctx, text):
+            """Renders reStructuredText text in HTML."""
+            parts = publish_parts(source=text, writer_name='html')
+            html = parts['body']
+            return html
+
+        @app.template_filter()
+        @evalcontextfilter
+        def docstring(eval_ctx, text):
+            try:
+                return rst(eval_ctx, text)
+            except:
+                return nl2br(eval_ctx, text)
 
     def doc(self, groups=None):
         """Add flask route to autodoc for automatic documentation

--- a/flask_autodoc/templates/autodoc_default.html
+++ b/flask_autodoc/templates/autodoc_default.html
@@ -69,7 +69,7 @@
                 </li>
                 {% endfor %}
             </ul>
-            <p class="docstring">{{doc.docstring|urlize|nl2br}}</p>
+            <p class="docstring">{{doc.docstring|docstring|safe}}</p>
         </div>
         {% endfor %}
     </body>

--- a/flask_autodoc/templates/autodoc_interactive.html
+++ b/flask_autodoc/templates/autodoc_interactive.html
@@ -1,0 +1,254 @@
+<html>
+    <head>
+        <title>
+            {% if title is defined -%}
+                {{title}}
+            {% else -%}
+                Documentation
+            {% endif -%}
+        </title>
+        <style>
+            * {
+                margin: 0;
+                padding: 0;
+                font-family: Verdana, "Helvetica Neue", Arial, Helvetica, Geneva, sans-serif;
+            }
+
+            body {
+                margin: 10px;
+            }
+
+            div.mapping {
+                margin: 20px 20px;
+                padding: 20px 20px;
+                border: 1px solid #000;
+            }
+
+            ul.methods:before { font-weight: bold;content: "Methods: "; }
+            ul.methods li {
+                display: inline;
+                list-style: none;
+            }
+            ul.methods li:after { content: ","; }
+            ul.methods li:last-child:after { content: ""; }
+
+            ul.arguments:before { font-weight: bold;content: "Path Arguments: "; }
+            ul.arguments li {
+                display: inline;
+                list-style: none;
+            }
+            ul.arguments .argument { font-style:italic }
+            ul.arguments .default:not(:empty):before { content: "("; }
+            ul.arguments .default:not(:empty):after { content: ")"; }
+            ul.arguments li:after { content: ","; }
+            ul.arguments li:last-child:after { content: ""; }
+            
+            ul.queryparams:before {font-weight: bold; content: "Query String Arguments: "; }
+            ul.queryparams li {
+                display: inline;
+                list-style: none;
+            }
+            ul.queryparams .argument { font-style:italic }
+            ul.queryparams .default:not(:empty):before { content: "("; }
+            ul.queryparams .default:not(:empty):after { content: ")"; }
+            ul.queryparams li:after { content: ","; }
+            ul.queryparams li:last-child:after { content: ""; }
+
+            .docstring:before { font-weight: bold; content: "Description: "; }
+            
+            .url-input {
+                width: 100%;
+            }
+            
+            .call-output, .call-status-code {
+                border: 1px solid #00B4FF;
+                display: none;
+                width: 100%;
+            }
+            
+            .post-data {
+                width: 100%;
+            }
+            
+            .mapping-description {
+                display: none;
+            }
+            
+            .rule h2 {
+                background-color: #B8F7FF;
+                cursor: pointer; cursor: hand;
+            }
+        </style>
+        <style>
+            .jsonview {
+              font-family: monospace;
+              font-size: .8em;
+              white-space: pre-wrap; }
+            .jsonview .prop {
+              font-weight: bold; }
+            .jsonview .null {
+              color: red; }
+            .jsonview .bool {
+              color: blue; }
+            .jsonview .num {
+              color: blue; }
+            .jsonview .string {
+              color: green;
+              white-space: pre-wrap; }
+            .jsonview .string.multiline {
+              display: inline-block;
+              vertical-align: text-top; }
+            .jsonview .collapser {
+              position: absolute;
+              left: -1em;
+              cursor: pointer; }
+            .jsonview .collapsible {
+              transition: height 1.2s;
+              transition: width 1.2s; }
+            .jsonview .collapsible.collapsed {
+              height: .8em;
+              width: 1em;
+              display: inline-block;
+              overflow: hidden;
+              margin: 0; }
+            .jsonview .collapsible.collapsed:before {
+              content: "...";
+              width: 1em;
+              margin-left: .2em; }
+            .jsonview .collapser.collapsed {
+              transform: rotate(0deg); }
+            .jsonview .q {
+              display: inline-block;
+              width: 0px;
+              color: transparent; }
+            .jsonview li {
+              position: relative; }
+            .jsonview ul {
+              list-style: none;
+              margin: 0 0 0 2em;
+              padding: 0; }
+            .jsonview h1 {
+              font-size: 1.2em; }
+        </style>
+        <script src="//code.jquery.com/jquery-2.1.1.min.js"></script>
+        <script type="text/javascript" >
+            !function(e){var n,t,l,r;return l=function(){function e(e){null==e&&(e={}),this.options=e}return e.prototype.htmlEncode=function(e){return null!==e?e.toString().replace(/&/g,"&amp;").replace(/"/g,"&quot;").replace(/</g,"&lt;").replace(/>/g,"&gt;"):""},e.prototype.jsString=function(e){return e=JSON.stringify(e).slice(1,-1),this.htmlEncode(e)},e.prototype.decorateWithSpan=function(e,n){return'<span class="'+n+'">'+this.htmlEncode(e)+"</span>"},e.prototype.valueToHTML=function(e,n){var t;return null==n&&(n=0),t=Object.prototype.toString.call(e).match(/\s(.+)]/)[1].toLowerCase(),this[""+t+"ToHTML"].call(this,e,n)},e.prototype.nullToHTML=function(){return this.decorateWithSpan("null","null")},e.prototype.numberToHTML=function(e){return this.decorateWithSpan(e,"num")},e.prototype.stringToHTML=function(e){var n,t;return/^(http|https|file):\/\/[^\s]+$/i.test(e)?'<a href="'+this.htmlEncode(e)+'"><span class="q">"</span>'+this.jsString(e)+'<span class="q">"</span></a>':(n="",e=this.jsString(e),this.options.nl2br&&(t=/([^>\\r\\n]?)(\\r\\n|\\n\\r|\\r|\\n)/g,t.test(e)&&(n=" multiline",e=(e+"").replace(t,"$1<br />"))),'<span class="string'+n+'">"'+e+'"</span>')},e.prototype.booleanToHTML=function(e){return this.decorateWithSpan(e,"bool")},e.prototype.arrayToHTML=function(e,n){var t,l,r,o,s,i,a,p;for(null==n&&(n=0),l=!1,s="",o=e.length,r=a=0,p=e.length;p>a;r=++a)i=e[r],l=!0,s+="<li>"+this.valueToHTML(i,n+1),o>1&&(s+=","),s+="</li>",o--;return l?(t=0===n?"":" collapsible",'[<ul class="array level'+n+t+'">'+s+"</ul>]"):"[ ]"},e.prototype.objectToHTML=function(e,n){var t,l,r,o,s,i;null==n&&(n=0),l=!1,o="",r=0;for(s in e)r++;for(s in e)i=e[s],l=!0,o+='<li><span class="prop"><span class="q">"</span>'+this.jsString(s)+'<span class="q">"</span></span>: '+this.valueToHTML(i,n+1),r>1&&(o+=","),o+="</li>",r--;return l?(t=0===n?"":" collapsible",'{<ul class="obj level'+n+t+'">'+o+"</ul>}"):"{ }"},e.prototype.jsonToHTML=function(e){return'<div class="jsonview">'+this.valueToHTML(e)+"</div>"},e}(),"undefined"!=typeof module&&null!==module&&(module.exports=l),t={bindEvent:function(e,n){var t;return t=document.createElement("div"),t.className="collapser",t.innerHTML=n?"+":"-",t.addEventListener("click",function(e){return function(n){return e.toggle(n.target)}}(this)),e.insertBefore(t,e.firstChild),n?this.collapse(t):void 0},expand:function(e){var n,t;return t=this.collapseTarget(e),n=t.parentNode.getElementsByClassName("ellipsis")[0],t.parentNode.removeChild(n),t.style.display="",e.innerHTML="-"},collapse:function(e){var n,t;return t=this.collapseTarget(e),t.style.display="none",n=document.createElement("span"),n.className="ellipsis",n.innerHTML=" &hellip; ",t.parentNode.insertBefore(n,t),e.innerHTML="+"},toggle:function(e){var n;return n=this.collapseTarget(e),"none"===n.style.display?this.expand(e):this.collapse(e)},collapseTarget:function(e){var n,t;return t=e.parentNode.getElementsByClassName("collapsible"),t.length?n=t[0]:void 0}},n=e,r={collapse:function(e){return"-"===e.innerHTML?t.collapse(e):void 0},expand:function(e){return"+"===e.innerHTML?t.expand(e):void 0},toggle:function(e){return t.toggle(e)}},n.fn.JSONView=function(){var e,o,s,i,a,p,c;return e=arguments,null!=r[e[0]]?(a=e[0],this.each(function(){var t,l;return t=n(this),null!=e[1]?(l=e[1],t.find(".jsonview .collapsible.level"+l).siblings(".collapser").each(function(){return r[a](this)})):t.find(".jsonview > ul > li > .collapsible").siblings(".collapser").each(function(){return r[a](this)})})):(i=e[0],p=e[1]||{},o={collapsed:!1,nl2br:!1},p=n.extend(o,p),s=new l({nl2br:p.nl2br}),"[object String]"===Object.prototype.toString.call(i)&&(i=JSON.parse(i)),c=s.jsonToHTML(i),this.each(function(){var e,l,r,o,s,i;for(e=n(this),e.html(c),r=e[0].getElementsByClassName("collapsible"),i=[],o=0,s=r.length;s>o;o++)l=r[o],i.push("LI"===l.parentNode.nodeName?t.bindEvent(l.parentNode,p.collapsed):void 0);return i}))}}(jQuery);
+        </script>
+        <script type="text/javascript" >
+            $(document).ready(function(){
+                $(".rule h2").on("click", function(){
+                    $(this).parents(".mapping").find(".mapping-description").slideToggle();
+                });
+                
+                $(".url-input").each(function(){
+                    $(this).val(location.protocol+"//"+location.host+$(this).parents(".mapping").find("a.rule h2").text())
+                });
+                
+                $(".send-request").on("click", function(){
+                    var url = $(this).parents(".mapping").find(".url-input").val();
+                    var method = $(this).val();
+                    var outputLocation = $(this).parents(".mapping").find(".call-output");
+                    $(outputLocation).empty()
+                    var statusLocation = $(this).parents(".mapping").find(".call-status-code");
+                    $(statusLocation).empty()
+                    if (method == "POST" || method == "PUT"){
+                        $.ajax({
+                            contentType:"application/json; charset=UTF-8;",
+                            data:$(this).parents(".mapping").find(".post-data").val(),
+                            method:method,
+                            url:url,
+                            success:function(data, status, jqXHR){
+                                $(outputLocation).JSONView(data);
+                                $(outputLocation).show();
+                                $(statusLocation).text("Status: "+jqXHR.status);
+                                $(statusLocation).show();
+                            },
+                            error:function(jqXHR, status, reason){
+                                if(~jqXHR.getResponseHeader("Content-Type").indexOf("application/json")){
+                                    $(outputLocation).JSONView(jqXHR.responseText);
+                                } else {
+                                    $(outputLocation).text(jqXHR.responseText);
+                                }
+                                $(outputLocation).show();
+                                $(statusLocation).text("Status: "+jqXHR.status);
+                                $(statusLocation).show();
+                            }
+                        });
+                    } else {
+                        $.ajax({
+                            contentType:"application/json; charset=UTF-8;",
+                            method:method,
+                            url:url,
+                            success:function(data, status, jqXHR){
+                                $(outputLocation).JSONView(data);
+                                $(outputLocation).show();
+                                $(statusLocation).text("Status: "+jqXHR.status);
+                                $(statusLocation).show();
+                            },
+                            error:function(jqXHR, status, reason){
+                                if(~jqXHR.getResponseHeader("Content-Type").indexOf("application/json")){
+                                    $(outputLocation).JSONView(jqXHR.responseText);
+                                } else {
+                                    $(outputLocation).text(jqXHR.responseText);
+                                }
+                                $(outputLocation).show();
+                                $(statusLocation).text("Status: "+jqXHR.status);
+                                $(statusLocation).show();
+                            }
+                        });
+                    }
+                });
+            });
+        </script>
+    </head>
+    <body>
+        <h1>
+            {% if title is defined -%}
+                {{title}}
+            {% else -%}
+                Documentation
+            {% endif -%}
+        </h1>
+
+        {% for doc in autodoc %}
+        <div class="mapping">
+            <a id="rule-{{doc.rule|urlencode}}" class="rule"><h2>{{doc.rule|escape}}</h2></a>
+            <div class="mapping-description">
+                <ul class="methods">
+                        {% for method in doc.methods -%}
+                        <li class="method">{{method}}</li>
+                        {% endfor %}
+                </ul>
+                <ul class="arguments">
+                    {% for arg in doc.args %}
+                    <li>
+                        <span class="argument">{{arg}}</span>
+                        <span class="default">{{doc.defaults[arg]}}</span>
+                    </li>
+                    {% endfor %}
+                </ul>
+                <p class="docstring">{{doc.docstring|urlize|nl2br}}</p>
+                <br/>
+                <p> <strong>URL:</strong> <input type="text" class="url-input"/></p>
+                <br/>
+                {% if "POST" in doc.methods or "PUT" in doc.methods %}
+                    <p><strong>Request Body:</strong> </p>
+                    <p><textarea class="post-data" rows=10 ></textarea></p>
+                    </br>
+                {% endif %}
+                <p>
+                {% for method in doc.methods %}
+                    {% if method != "OPTIONS" %}
+                        <input type="button" class="send-request" value="{{method}}"/>
+                    {% endif %}
+                {% endfor %}
+                </p><br/>
+                <p class="call-status-code"></p>
+                <p class="call-output"></p>
+            </div>
+        </div>
+    {% endfor %}
+    
+    
+    </body>
+</html>

--- a/flask_autodoc/templates/autodoc_interactive.html
+++ b/flask_autodoc/templates/autodoc_interactive.html
@@ -89,6 +89,10 @@
             blockquote p, blockquote pre {
                 margin-bottom: 1em;
             }
+            
+            .line-block {
+                margin-left: 2em;
+            }
         </style>
         <style>
             .jsonview {

--- a/flask_autodoc/templates/autodoc_interactive.html
+++ b/flask_autodoc/templates/autodoc_interactive.html
@@ -81,7 +81,7 @@
             
             pre {
                 font-family: monospace;
-                overflow-x: scroll;
+                overflow-x: auto;
                 border: 1px solid #000;
                 background: #eef;
             }

--- a/flask_autodoc/templates/autodoc_interactive.html
+++ b/flask_autodoc/templates/autodoc_interactive.html
@@ -78,6 +78,17 @@
                 background-color: #B8F7FF;
                 cursor: pointer; cursor: hand;
             }
+            
+            pre {
+                font-family: monospace;
+                overflow-x: scroll;
+                border: 1px solid #000;
+                background: #eef;
+            }
+            
+            blockquote p, blockquote pre {
+                margin-bottom: 1em;
+            }
         </style>
         <style>
             .jsonview {
@@ -227,7 +238,7 @@
                     </li>
                     {% endfor %}
                 </ul>
-                <p class="docstring">{{doc.docstring|urlize|nl2br}}</p>
+                <p class="docstring">{{doc.docstring|docstring|safe}}</p>
                 <br/>
                 <p> <strong>URL:</strong> <input type="text" class="url-input"/></p>
                 <br/>

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     # if you would be using a package instead use packages instead
     # of py_modules:
     packages=['flask_autodoc'],
-    package_data={'flask_autodoc': ['templates/autodoc_default.html']},
+    package_data={'flask_autodoc': ['templates/autodoc_default.html', 'templates/autodoc_interactive.html']},
     zip_safe=False,
     include_package_data=True,
     platforms='any',


### PR DESCRIPTION
This adds a more interactive documentation page, with such exciting features as:
- collapsible sections
- the ability to try REST calls on the page and see the response (similar to a swagger-ui like this: http://petstore.swagger.wordnik.com/)
- python 3 support
- The ability to document query string args by adding some parameters to the decorator
- A little colorizing and borderizing to make long docs a little more readable