### PR TITLE
Custom Function Properties

### DIFF
--- a/examples/custom/blog.py
+++ b/examples/custom/blog.py
@@ -57,11 +57,10 @@ def get_post(id):
 
 
 @app.route('/post', methods=["POST"])
-@auto.doc(groups=['posts', 'private'])
+@auto.doc(groups=['posts', 'private'],
+    form_data=['title', 'content', 'authorid'])
 def post_post():
-    """Create a new post.
-    Form Data: title, content, authorid.
-    """
+    """Create a new post."""
     authorid = request.form.get('authorid', None)
     Post(request.form['title'],
          request.form['content'],
@@ -84,11 +83,10 @@ def get_user(id):
 
 
 @app.route('/users', methods=['POST'])
-@auto.doc(groups=['users', 'private'])
+@auto.doc(groups=['users', 'private'],
+    form_data=['username'])
 def post_user(id):
-    """Creates a new user.
-    Form Data: username.
-    """
+    """Creates a new user."""
     User(request.form['username'])
     redirect('/users')
 

--- a/examples/custom/templates/autodoc_custom.html
+++ b/examples/custom/templates/autodoc_custom.html
@@ -22,7 +22,7 @@
                 margin: 20px 20px;
             }
 
-            .location { font-style: italic;}
+            .location { font-style: italic; }
 
             ul.methods:before { content: "Methods: "; }
             ul.methods li {
@@ -43,6 +43,11 @@
             ul.arguments li:after { content: ","; }
             ul.arguments li:last-child:after { content: ""; }
 
+            ul.property li {
+                display: inline;
+                list-style: none;
+            }
+
             .docstring:before { content: "Description: "; }
         </style>
     </head>
@@ -60,9 +65,9 @@
             <a id="rule-{{doc.rule|urlencode}}" class="rule"><h2>{{doc.rule|escape}}</h2></a>
             <p class="location">{{doc.location.filename}}:{{doc.location.line}}</p>
             <ul class="methods">
-                    {% for method in doc.methods -%}
-                    <li class="method">{{method}}</li>
-                    {% endfor %}
+                {% for method in doc.methods -%}
+                <li class="method">{{method}}</li>
+                {% endfor %}
             </ul>
             <ul class="arguments">
                 {% for arg in doc.args %}
@@ -70,6 +75,11 @@
                     <span class="argument">{{arg}}</span>
                     <span class="default">{{doc.defaults[arg]}}</span>
                 </li>
+                {% endfor %}
+            </ul>
+            <ul class="property">
+                {% for prop in doc if prop not in defaults %}
+                <li class="property">{{prop}}:{{doc[prop]}}</br></li>
                 {% endfor %}
             </ul>
             <p class="docstring">{% autoescape false %}{{doc.docstring|urlize|nl2br}}{% endautoescape %}</p>


### PR DESCRIPTION
Added variable args to the doc decorator that add custom variables to a route's documentation.

These variables are passed into the documentation that is generated and can be used in the template to have more customized and structured data (e.g. query string parameters, post form data, expected content types, etc.) without having to put everything in the docstring, making those properties easier to deal with when working with a template.

The default template has also been modified to display these custom properties in a similar fashion as the default ones. However, the data is currently only displayed as raw string conversions from python, with no formatting changes.

Additionally, some existing function properties can be overridden by specifying them in the decorator.
I hardcoded a variable in autodoc that defines which properties cannot be overridden, these are currently 'rule' and 'endpoint'.
