### PR TITLE
Add an example of an API generated using Flask-Restless.

### DIFF
--- a/examples/restless-api/blog.py
+++ b/examples/restless-api/blog.py
@@ -1,0 +1,32 @@
+from flask import Flask
+from flask.ext.autodoc import Autodoc
+from flask.ext.restless import APIManager
+from flask.ext.sqlalchemy import SQLAlchemy
+
+app = Flask(__name__)
+app.debug = True
+auto = Autodoc(app)
+app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:////tmp/test.db'
+db = SQLAlchemy(app)
+manager = APIManager(app, flask_sqlalchemy_db=db)
+
+class User(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    username = db.Column(db.String(80), unique=True)
+    email = db.Column(db.String(120), unique=True)
+
+class Post(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    title = db.Column(db.String(40), unique=True)
+    content = db.Column(db.String(300))
+
+# Create API endpoints for SQLAlchemy models:
+manager.create_api(User)
+manager.create_api(Post, methods=['GET', 'POST', 'DELETE'])
+
+# Decorate all endpoints with Autodoc.doc():
+for endpoint, function in app.view_functions.iteritems():
+    app.view_functions[endpoint] = auto.doc()(function)
+
+if __name__ == '__main__':
+    app.run()


### PR DESCRIPTION
This example shows how to do an important use case - generating several endpoints using a Flask plugin for REST APIs, then programmatically decorating all the endpoints with `doc()`.

This example is closely based on the `simple` example. However, it has two requirements extra to the requirement for Flask of the main package - `Flask-Restless` and `Flask-SQLAlchemy`. It doesn't seem like these should be added to the `requirements.txt` of the main package.