### PR TITLE
Fix autoescaping in custom template example

### DIFF
--- a/examples/custom/templates/autodoc_custom.html
+++ b/examples/custom/templates/autodoc_custom.html
@@ -72,7 +72,7 @@
                 </li>
                 {% endfor %}
             </ul>
-            <p class="docstring">{{doc.docstring|urlize|nl2br}}</p>
+            <p class="docstring">{% autoescape false %}{{doc.docstring|urlize|nl2br}}{% endautoescape %}</p>
         </div>
         {% endfor %}
     </body>


### PR DESCRIPTION
When you use a custom template, Autodoc uses `render_template()`. But the default template is rendered with `render_template_string()` (see [here](https://github.com/acoomans/flask-autodoc/blob/0.1.2/flask_autodoc/autodoc.py#L153-L169)). Apparently, those functions handle autoescaping differently.

## Before
```jinja
<p class="docstring">{{doc.docstring|urlize|nl2br}}</p>
```

Python2:
![autodoc-issue-before-python2](https://cloud.githubusercontent.com/assets/687269/9770298/545d86c8-56e4-11e5-92b9-1331b11ae8bc.jpg)
Python3:
![autodoc-issue-before-python3](https://cloud.githubusercontent.com/assets/687269/9770301/5a087560-56e4-11e5-9a21-513d6adcee29.jpg)

## After
```jinja
<p class="docstring">{% autoescape false %}{{doc.docstring|urlize|nl2br}}{% endautoescape %}</p>
```

Python2/3:
![autodoc-issue-after](https://cloud.githubusercontent.com/assets/687269/9770358/a9e871fc-56e4-11e5-86c0-1634b293011b.jpg)