### PR TITLE
Issue #27 fix, ExtDeprecationWarning on load

### DIFF
--- a/flask_autodoc/__init__.py
+++ b/flask_autodoc/__init__.py
@@ -1,3 +1,3 @@
 __author__ = 'arnaud'
 
-from flask.ext.autodoc.autodoc import Autodoc
+from flask_autodoc.autodoc import Autodoc


### PR DESCRIPTION
This patches Issue #27, the warning form deprecated load in __init__.py in python 3