### PR TITLE
Silence ExtDeprecationWarning and replace all references in project

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ or clone this directory and run setup:
 Start using Flask-Autodoc by importing it and initializing it:
 
     from flask import Flask
-    from flask.ext.autodoc import Autodoc
+    from flask_autodoc import Autodoc
 
     app = Flask(__name__)
     auto = Autodoc(app)

--- a/examples/custom/blog.py
+++ b/examples/custom/blog.py
@@ -2,7 +2,7 @@ from os import path
 from json import dumps
 
 from flask import Flask, redirect, request
-from flask.ext.autodoc import Autodoc
+from flask_autodoc import Autodoc
 
 
 app = Flask(__name__)

--- a/examples/factory/blog/doc.py
+++ b/examples/factory/blog/doc.py
@@ -1,5 +1,5 @@
 from flask import Blueprint
-from flask.ext.autodoc import Autodoc
+from flask_autodoc import Autodoc
 
 
 doc = Blueprint('doc', __name__, url_prefix='/doc')

--- a/examples/simple/blog.py
+++ b/examples/simple/blog.py
@@ -1,7 +1,7 @@
 from json import dumps
 
 from flask import Flask, redirect, request
-from flask.ext.autodoc import Autodoc
+from flask_autodoc import Autodoc
 
 
 app = Flask(__name__)

--- a/flask_autodoc/__init__.py
+++ b/flask_autodoc/__init__.py
@@ -1,3 +1,3 @@
 __author__ = 'arnaud'
 
-from flask.ext.autodoc.autodoc import Autodoc
+from flask_autodoc.autodoc import Autodoc

--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -5,7 +5,7 @@ import sys
 import os
 
 from flask import Flask
-from flask.ext.autodoc import Autodoc
+from flask_autodoc import Autodoc
 
 
 class TestAutodoc(unittest.TestCase):


### PR DESCRIPTION
This fixes the `ExtDeprecationWarning` referenced in #27 for both the package and the tests, and replaces all references to `flask.ext.autodoc` with `flask_autodoc` throughout the project, including the README.