### PR TITLE
flask.ext.autodoc is deprecated, use flask_autodoc

### DIFF
--- a/flask_autodoc/__init__.py
+++ b/flask_autodoc/__init__.py
@@ -1,3 +1,3 @@
 __author__ = 'arnaud'
 
-from flask.ext.autodoc.autodoc import Autodoc
+from flask_autodoc.autodoc import Autodoc


### PR DESCRIPTION
As of Flask 0.11, most Flask extensions have transitioned to the new naming schema. The flask.ext.foo compatibility alias is still in Flask 0.11 but is now deprecated – you should use flask_foo.