### PR TITLE
safe option for docstring insert

### DIFF
--- a/flask_autodoc/templates/autodoc_default.html
+++ b/flask_autodoc/templates/autodoc_default.html
@@ -75,7 +75,7 @@
                 </li>
                 {% endfor %}
             </ul>
-            <p class="docstring">{{doc.docstring|urlize|nl2br}}</p>
+            <p class="docstring">{{doc.docstring|urlize|nl2br|safe}}</p>
         </div>
         {% endfor %}
     </body>


### PR DESCRIPTION
safe option disables auto escaping for html pre fomatted docstring
resolving issue #26 