### PR TITLE
update import, compatible to flask 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ or clone this directory and run setup:
 Start using Flask-Autodoc by importing it and initializing it:
 
     from flask import Flask
-    from flask.ext.autodoc import Autodoc
+    from flask_autodoc import Autodoc
 
     app = Flask(__name__)
     auto = Autodoc(app)


### PR DESCRIPTION
import flask.ext.* is no longer supported in flask 1.0
see: https://github.com/acoomans/flask-autodoc/pull/25#pullrequestreview-189380765
see also: https://stackoverflow.com/a/50589932/1387828