### PR TITLE
Fixed Broken Broken Reference to Application

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ virtualenv
 venv
 
 .idea
+Dockerfile

--- a/examples/custom/blog.py
+++ b/examples/custom/blog.py
@@ -2,7 +2,7 @@ from os import path
 from json import dumps
 
 from flask import Flask, redirect, request
-from flask.ext.autodoc import Autodoc
+from flask_autodoc import Autodoc
 
 
 app = Flask(__name__)

--- a/examples/factory/blog/doc.py
+++ b/examples/factory/blog/doc.py
@@ -1,5 +1,5 @@
 from flask import Blueprint
-from flask.ext.autodoc import Autodoc
+from flask_autodoc import Autodoc
 
 
 doc = Blueprint('doc', __name__, url_prefix='/doc')

--- a/examples/simple/blog.py
+++ b/examples/simple/blog.py
@@ -1,7 +1,7 @@
 from json import dumps
 
 from flask import Flask, redirect, request
-from flask.ext.autodoc import Autodoc
+from flask_autodoc import Autodoc
 
 
 app = Flask(__name__)

--- a/flask_autodoc/__init__.py
+++ b/flask_autodoc/__init__.py
@@ -1,3 +1,3 @@
 __author__ = 'arnaud'
 
-from flask.ext.autodoc.autodoc import Autodoc
+from flask_autodoc.autodoc import Autodoc

--- a/flask_autodoc/autodoc.py
+++ b/flask_autodoc/autodoc.py
@@ -6,7 +6,7 @@ import sys
 import inspect
 
 from flask import current_app, render_template, render_template_string
-from jinja2 import evalcontextfilter
+from jinja2 import pass_eval_context
 
 
 try:
@@ -55,7 +55,7 @@ class Autodoc(object):
         _paragraph_re = re.compile(r'(?:\r\n|\r|\n){3,}')
 
         @app.template_filter()
-        @evalcontextfilter
+        @pass_eval_context
         def nl2br(eval_ctx, value):
             result = '\n\n'.join('%s' % p.replace('\n', '<br>\n')
                                  for p in _paragraph_re.split(value))

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def readme():
 
 setup(
     name='Flask-Autodoc',
-    version='0.1.2',
+    version='0.2.0',
     url='http://github.com/acoomans/flask-autodoc',
     license='MIT',
     author='Arnaud Coomans',

--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -5,7 +5,7 @@ import sys
 import os
 
 from flask import Flask
-from flask.ext.autodoc import Autodoc
+from flask_autodoc import Autodoc
 
 
 class TestAutodoc(unittest.TestCase):

--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -259,7 +259,7 @@ class TestAutodoc(unittest.TestCase):
             self.assertIn('Returns arguments', doc)
 
     def testLocation(self):
-        line_no = inspect.stack()[0][2] + 2 # the doc() line
+        line_no = inspect.stack()[0][2] + 3 # the doc() line
         @self.app.route('/location')
         @self.autodoc.doc()
         def location():


### PR DESCRIPTION
The `flask.ext.module` method of importing has been long depreciated. Updated the reference to fix this.